### PR TITLE
Revert "feat: bump go to 1.22"

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnolang/supernova
 
-go 1.22
+go 1.21
 
 require (
 	github.com/peterbourgon/ff/v3 v3.4.0


### PR DESCRIPTION
This reverts commit a6720c0870118fe4cde4cd1d61b30a56c6f3be96 to Go 1.21.
Go 1.21 is the last version supported for releases.