### PR TITLE
Fixing support to TLS for Docker image

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,5 @@
+name: Lint Go Code
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,5 @@
+name: Main Branch - Build & Test
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,5 @@
+name: Go Tests
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,3 +1,4 @@
-FROM scratch
+# NOTE: using `scratch` as BASE image wouls lack of CA certicates
+FROM golang:1.23-alpine
 COPY supernova /
 ENTRYPOINT [ "/supernova" ]


### PR DESCRIPTION
Supernova docker image built by `goreleaser` employs `scratch` as base image.

However this image is an empty base image, that lacks of CA certificates for TLS.
Suggesting `golang:1.23-alpine` as alternative working base image
