### PR TITLE
chore: moving binary in path folder

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
 # NOTE: using `scratch` as BASE image would lack of CA certicates
 FROM golang:1.23-alpine
-COPY supernova /
-ENTRYPOINT [ "/supernova" ]
+COPY supernova /usr/bin/supernova
+ENTRYPOINT [ "/usr/bin/supernova" ]


### PR DESCRIPTION
Move binary into folder in PATH for sake of simplicity